### PR TITLE
Add CODEOWNERS file for code review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# CODEOWNERS file for OCN Common
+# This file defines who should review changes to specific parts of the codebase
+# 
+# For more information about CODEOWNERS files, see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global ownership - all files require review from @ahsanazmi1
+*                 @ahsanazmi1
+
+# Source code ownership
+/src/            @ahsanazmi1
+
+# Test code ownership  
+/tests/          @ahsanazmi1
+
+# GitHub configuration ownership
+/.github/        @ahsanazmi1
+
+# Documentation ownership
+/docs/           @ahsanazmi1
+
+# Infrastructure and deployment ownership
+/infra/          @ahsanazmi1
+
+# Examples and samples ownership
+/examples/       @ahsanazmi1
+
+# Common schemas and contracts ownership
+/common/         @ahsanazmi1


### PR DESCRIPTION
- Define code ownership rules for all repository paths
- Require @ahsanazmi1 review for all changes
- Enable branch protection rules to enforce CODEOWNERS reviews
- Cover all critical directories: /src/, /tests/, /.github/, /docs/, /infra/, /examples/, /common/